### PR TITLE
removed body-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "bcrpyt": "^2.0.0",
     "bcrypt": "^1.0.3",
     "bluebird": "^3.5.1",
-    "body-parser": "^1.18.2",
     "connect-multiparty": "^2.1.0",
     "cors": "^2.8.4",
     "express": "^4.16.3",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const sqlite3 = require("sqlite3").verbose();
 const multipart = require("connect-multiparty");
 const cors = require("cors");
@@ -9,14 +8,15 @@ const jwt = require("jsonwebtoken");
 const bcrypt = require("bcrypt");
 const saltRounds = 10;
 
+
 // Set Application Port
 const PORT = process.env.PORT || 3128;
 
 // create express app
 const app = express();
 app.use(cors());
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.set("appSecret", "secretforinvoicingapp");
 


### PR DESCRIPTION
since express >= 4.16.2 already have the body-parser module/middleware built in, no need for the extra dependency